### PR TITLE
Update helpers.ts

### DIFF
--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -24,7 +24,7 @@ function matchesCriteria(document: IVSDocument<any>, criteria: IVSFilterCriteria
   }
   if (criteria.text) {
     const texts = Array.isArray(criteria.text) ? criteria.text : [criteria.text];
-    if (!texts.includes(document.text)) {
+    if (!texts.some(word => document.text.includes(word))) {
       return false;
     }
   }


### PR DESCRIPTION
The current `matchesCriteria` method for `criteria.text` does not seem very effective. 

```js
  if (criteria.text) {
    const texts = Array.isArray(criteria.text) ? criteria.text : [criteria.text];
    if (!texts.includes(document.text)) {
      return false;
    }
  }
```

This means if `criteria.text` (or elements in an array passed in as it's value) is not an exact match to `document.text`, we'll get no results.

Unless that is by design, I propose the following minor change.